### PR TITLE
Change hosted link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Download and copy the `.js` file to your project folder and include it in your H
 
 ### Hosted
 
-Link the `.js` file as an external resource from *GitHub* site:
+Link the `.js` file as an external resource from *jsDelivr* CDN:
 
 ```html
-<script src="https://zuixjs.github.io/zuix/js/zuix.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/zuix"></script>
 ```
 
 ### NPM

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "zuix",
   "version": "1.0.3",
   "description": "zUIx is a JavaScript library for creating component-based websites and applications.",
+  "main": "dist/js/zuix.min.js",
   "typings": "dist/ts/zuix.d.ts",
   "scripts": {
     "info": "echo 'zUIx.js, friendly component-based web development.'",


### PR DESCRIPTION
I replaced the GitHub link with a  [jsDelivr CDN link](https://www.jsdelivr.com/) in the readme, as jsDelivr was built and is better for this use case unlike GitHub. 